### PR TITLE
(RN0.40.0) Fixed ios native headers

### DIFF
--- a/PasscodeAuth.h
+++ b/PasscodeAuth.h
@@ -1,4 +1,4 @@
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface PasscodeAuth : NSObject <RCTBridgeModule>
 

--- a/PasscodeAuth.m
+++ b/PasscodeAuth.m
@@ -1,5 +1,5 @@
 #import "PasscodeAuth.h"
-#import "RCTUtils.h"
+#import <React/RCTUtils.h>
 #import <LocalAuthentication/LocalAuthentication.h>
 
 @implementation PasscodeAuth


### PR DESCRIPTION
The import syntax has changed in react-native v0.40.0.
ref. https://github.com/facebook/react-native/releases/tag/v0.40.0

This PR follows new import syntax,
and need a major version bump for react-native 0.40.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naoufal/react-native-passcode-auth/8)
<!-- Reviewable:end -->
